### PR TITLE
Add streaming account manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+accounts.json
+test_accounts.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Streaming Account Manager
+
+Este proyecto proporciona un ejemplo sencillo de un sistema para gestionar
+cuentas de servicios de streaming. Incluye una utilidad en Python para
+agregar, eliminar, actualizar y listar cuentas almacenadas en un archivo JSON.
+
+## Requisitos
+
+- Python 3.8 o superior
+
+## Uso
+
+Ejecute la interfaz de línea de comandos:
+
+```bash
+python -m streaming_manager.manager add --username usuario1 --service netflix --plan basico
+python -m streaming_manager.manager list
+```
+
+Los datos se almacenan en `accounts.json` por defecto. Puede especificar otro
+archivo con el parámetro `--storage`.
+
+## Pruebas
+
+Para ejecutar las pruebas unitarias:
+
+```bash
+python -m unittest discover -s streaming_manager/tests
+```

--- a/streaming_manager/manager.py
+++ b/streaming_manager/manager.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+def load_accounts(path: Path) -> List[Dict]:
+    if path.exists():
+        with path.open('r', encoding='utf-8') as f:
+            return json.load(f)
+    return []
+
+def save_accounts(path: Path, accounts: List[Dict]):
+    with path.open('w', encoding='utf-8') as f:
+        json.dump(accounts, f, indent=2)
+
+def add_account(path: Path, account: Dict):
+    accounts = load_accounts(path)
+    accounts.append(account)
+    save_accounts(path, accounts)
+
+def remove_account(path: Path, username: str):
+    accounts = load_accounts(path)
+    accounts = [a for a in accounts if a.get('username') != username]
+    save_accounts(path, accounts)
+
+def update_account(path: Path, username: str, updates: Dict):
+    accounts = load_accounts(path)
+    for acc in accounts:
+        if acc.get('username') == username:
+            acc.update(updates)
+    save_accounts(path, accounts)
+
+def list_accounts(path: Path) -> List[Dict]:
+    return load_accounts(path)
+
+def cli():
+    import argparse
+    parser = argparse.ArgumentParser(description='Manage streaming accounts')
+    parser.add_argument('action', choices=['add', 'remove', 'update', 'list'])
+    parser.add_argument('--username')
+    parser.add_argument('--service')
+    parser.add_argument('--plan')
+    parser.add_argument('--data', help='Additional data as JSON string')
+    parser.add_argument('--storage', default='accounts.json')
+    args = parser.parse_args()
+    path = Path(args.storage)
+
+    if args.action == 'add':
+        if not args.username:
+            parser.error('username required for add')
+        account = {'username': args.username, 'service': args.service, 'plan': args.plan}
+        if args.data:
+            account.update(json.loads(args.data))
+        add_account(path, account)
+    elif args.action == 'remove':
+        if not args.username:
+            parser.error('username required for remove')
+        remove_account(path, args.username)
+    elif args.action == 'update':
+        if not args.username:
+            parser.error('username required for update')
+        updates = {}
+        if args.service:
+            updates['service'] = args.service
+        if args.plan:
+            updates['plan'] = args.plan
+        if args.data:
+            updates.update(json.loads(args.data))
+        update_account(path, args.username, updates)
+    elif args.action == 'list':
+        accounts = list_accounts(path)
+        print(json.dumps(accounts, indent=2))
+
+if __name__ == '__main__':
+    cli()

--- a/streaming_manager/tests/test_manager.py
+++ b/streaming_manager/tests/test_manager.py
@@ -1,0 +1,30 @@
+import os
+import json
+import unittest
+from pathlib import Path
+from streaming_manager import manager
+
+class ManagerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmpfile = Path('test_accounts.json')
+        if self.tmpfile.exists():
+            self.tmpfile.unlink()
+
+    def tearDown(self):
+        if self.tmpfile.exists():
+            self.tmpfile.unlink()
+
+    def test_add_and_list(self):
+        manager.add_account(self.tmpfile, {'username': 'user1', 'service': 'netflix', 'plan': 'basic'})
+        accounts = manager.list_accounts(self.tmpfile)
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]['username'], 'user1')
+
+    def test_remove(self):
+        manager.add_account(self.tmpfile, {'username': 'user1', 'service': 'netflix', 'plan': 'basic'})
+        manager.remove_account(self.tmpfile, 'user1')
+        accounts = manager.list_accounts(self.tmpfile)
+        self.assertEqual(len(accounts), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Python example to manage streaming accounts
- provide README instructions and unit tests

## Testing
- `python -m unittest discover -s streaming_manager/tests`

------
https://chatgpt.com/codex/tasks/task_e_6886792362488320a7732f84fe0f38d1